### PR TITLE
Fixed Issue 11 and 17

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -79,13 +79,10 @@ function sync {
 
   # check what has changed
   touch "$STATE_DIR/tree-prev"
-  find . | sort | cut -d '.' -f 2- | egrep -v "^/$DOT_DIR" > "$STATE_DIR/tree-current"
+  find . -printf "/%P\0" | egrep -vzZ "^/$DOT_DIR" > "$STATE_DIR/tree-current"
 
-  # prevent bringing back locally deleted files
-  comm -23 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" >"$TMP_DIR/fetch-exclude"
-
-  # prevent removing new local files
-  comm -13 "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" >>"$TMP_DIR/fetch-exclude"
+  # prevent bringing back locally deleted files or removing new local files
+  sort -z "$STATE_DIR/tree-prev" "$STATE_DIR/tree-current" | uniq -u -z > "$TMP_DIR/fetch-exclude"
 
   # don't sync user excluded files
   if [ -f "$DOT_DIR/exclude" ]; then
@@ -96,16 +93,18 @@ function sync {
   on_slow_sync_start
 
   # fetch everything new and updated, locally remove files deleted on remote
-  rsync -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $user_exclude --exclude-from "$TMP_DIR/fetch-exclude" $REMOTE/ . || die
+  echo  "Fetching changes from server"
+  rsync -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $user_exclude --from0 --exclude-from "$TMP_DIR/fetch-exclude" $REMOTE/ . || die
 
   # send new and updated, remotely remove files deleted locally
-  rsync -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $user_exclude . $REMOTE/ || die
+  echo "Pushing changes to server"
+  rsync -auvzxi --delete $RSYNC_OPTS --exclude "/$DOT_DIR" $user_exclude --from0 . $REMOTE/ || die
 
   # fire off slow sync stop notifier in background
   on_slow_sync_stop
 
-  # save tree state for next run
-  mv "$STATE_DIR/tree-current" "$STATE_DIR/tree-prev"
+  # save new tree state for next run
+  find . -printf "/%P\0" | egrep -vzZ "^/$DOT_DIR" > "$STATE_DIR/tree-prev"
 
   cleanup
 }


### PR DESCRIPTION
- The exclude list is now NULL terminated to allow for arbitrary files
  names such as those which contain newline characters.
- Current tree is regenerated after sync to account for deleted / new
  files
