### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ bitpocket directory:
     $ cd ~/BitPocket
     $ bitpocket sync
 
+Ensure that you run bitpocket at least once while both directories are empty.  You may then move files
+into one of the directories and they will be detected as added.
 
 ### Automatic sync with cron
 


### PR DESCRIPTION
I followed the instructions as written.  However, what was not clear was the sequence for data to begin synchronizing.  It appears that bitpocket sync must be run at least once after bitpocket init while both directories are empty.

In my case, the directories were empty, I ran bitpocket init on the slave, moved my data to the master, and began the sync on the slave.  bitpocket then deleted all my data.

Since a small error in sequence can have such a devastating effect, these isntructions need to be much more explicit.  As currently written, they say nothing about when it is Ok to move data into one of the directories.
