### PR TITLE
timestamps each log entry

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -139,7 +139,14 @@ function on_slow_sync_stop {
 }
 
 function cron {
-  DISPLAY=:0.0 sync 2>&1 >>"$DOT_DIR/log"
+  DISPLAY=:0.0 sync 2>&1 | timestamp >>"$DOT_DIR/log"
+}
+
+function timestamp {
+  while read data
+  do
+      echo "[$(date +"%D %T")] $data"
+  done
 }
 
 function acquire_lock {


### PR DESCRIPTION
So, here it is.

I ran "rake tests", and one test failed, but it has something to do with locking, so I don't think I broke anything:

```
  1) bitpocket locking exits with status 1 when other instance is running
     Failure/Error: sync.should exit_with(1)
       expected 2 to exit with 1
     # /home/lucastx/src/bitpocket/spec/locking_spec.rb:9:in `block (2 levels) in <top (required)>'
```
