### PR TITLE
Allow initializing w/ empty hostname (=local); remote paths with spaces; FAT hints

### DIFF
--- a/bin/bitpocket
+++ b/bin/bitpocket
@@ -65,8 +65,8 @@ function init {
     exit 128
   fi
 
-  if [[ $# != 2 ]]; then
-    echo "usage: bitpocket init <REMOTE_HOST> <REMOTE_PATH>"
+  if [[ -z "$2" || -n "$3" ]]; then
+    echo "usage: bitpocket init {<REMOTE_HOST> | \"\"} <REMOTE_PATH>"
     exit 128
   fi
 
@@ -343,7 +343,8 @@ function list {
 }
 
 function usage {
-  echo "usage:  bitpocket [sync|help|pack|log|cron|list|init <REMOTE_HOST> <REMOTE_PATH>]"
+  echo "usage:  bitpocket [sync | help | pack | log | cron | list]"
+  echo "        bitpocket init {<REMOTE_HOST> | \"\"} <REMOTE_PATH>"
   echo ""
   echo "Available commands:"
   echo "   sync    Run the sync process. If no command is specified, sync is run by default."
@@ -362,7 +363,7 @@ function usage {
 
 if [ "$1" = "init" ]; then
   # Initialize bitpocket directory
-  init $2 $3 $4
+  init "$2" "$3" "$4"
 elif [ "$1" = "pack" ]; then
   # Pack backups using git
   pack


### PR DESCRIPTION
A few minor fixes and user hints to make setup for syncing to transiently mounted USB devices with funny mountpoint names just a little smoother. FAT filesystems are pretty much a standard on these things; spaces in the names are common, and the things are almost always found locally attached. It's a use case which unison fails spectacularly badly at, to the extent of forcing a full comparison the first time on each new mount. rsync is dumber, so bitpocket seems to handle it better, given the right options.
